### PR TITLE
Fixed squished text on Topics page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -120,6 +120,10 @@ a.taglink {
   padding-top:2em;
 }
 
+.panel {
+  line-height: 1.3em;
+}
+
 .panel_offset_link {
   font-size:0.75em; padding-top:1.75rem; text-align:right; margin-bottom:-14px;
 }
@@ -138,7 +142,10 @@ a.taglink {
   p {
     padding-top: 0.45rem;
     margin-bottom: 0.7rem;
-    line-height: 0.9rem;
+    line-height: 1.2rem;
+  }
+  .subtopics {
+    font-size: 0.6em;
   }
   .topic_icon {
     padding-right:5px;
@@ -150,8 +157,8 @@ a.taglink {
   }
   .title {
     font-size:1.5rem;
-    font-weight:110%;
-    line-height:0.9rem
+    font-weight: 500;
+    line-height: 1.5rem;
   }
   .taglist {
     float: right;
@@ -169,9 +176,6 @@ a.taglink {
 .topic_index_element:hover .delete_topic {
   visibility: visible;
   opacity: 1;
-}
-.topic_index_element .subtopics {
-  font-size: .5em;
 }
 .center {
   text-align: center

--- a/app/views/topics/index.html.haml
+++ b/app/views/topics/index.html.haml
@@ -30,5 +30,5 @@
   .columns.large-8
     = will_paginate @topics
   .columns.large-4.center
-    = link_to 'Create new Topic', new_topic_path, :class=>'button tiny'
+    = link_to 'Create new Topic', new_topic_path, :class=>'button small'
 


### PR DESCRIPTION
Just some small fixes for readability.

-Made the topics title text non-squished. Fixed the font weight because 110% was not a valid property value.
-Also made the topics summary non-squished.
-Made the subtopic text just a tiny bit bigger.
-Made the 'Create Topic' button a tiny bit bigger so you could see the text in it easier.
-Made the panel text non-squished.
