### PR TITLE
Add year to "asked by" and "answered by" dates

### DIFF
--- a/app/views/shared/_answered_by.html.haml
+++ b/app/views/shared/_answered_by.html.haml
@@ -4,4 +4,4 @@
     = user && user.name
     answered
     %br/
-    on #{l(at, format: :short)}
+    on #{l(at, format: :medium)}

--- a/app/views/shared/_asked_by.html.haml
+++ b/app/views/shared/_asked_by.html.haml
@@ -4,4 +4,4 @@
     = user && user.name
     asked on
     %br/
-    = l(at, format: :short)
+    = l(at, format: :medium)


### PR DESCRIPTION
I've had a few times recently that have made me wonder if a question was answered a month ago or over a year ago. 