### PR TITLE
Include year in topic history

### DIFF
--- a/app/views/topics/_history.html.haml
+++ b/app/views/topics/_history.html.haml
@@ -4,7 +4,7 @@
     -# next if index != 0 && v.whodunnit.nil? || (v.changeset[:content] && !v.changeset[:content].any?(&:present?))
     %li
       - username = User.find_by_id(v.whodunnit).try(:name) || "Unknown"
-      - str = "#{l(v.created_at, format: :civilian)} #{username}"
+      - str = "#{l(v.created_at, format: :long)} #{username}"
       - if @static_render
         = str
       - else


### PR DESCRIPTION
Change the localization format to `:long` so that the year is displayed along with the history.  The date/time is now a little long so some ugly wrapping can occur, but it was happening anyway...