### PR TITLE
Fix HTML truncation

### DIFF
--- a/app/views/questions/index.html.haml
+++ b/app/views/questions/index.html.haml
@@ -46,7 +46,7 @@
             .row
               .columns.large-9
                 .question_answer
-                  = raw HTML_Truncator.truncate( render_md(question.text).html_safe, 45)
+                  = raw HTML_Truncator.truncate( render_md(question.text).html_safe, 120, {:length_in_chars => true})
             .row
               .columns.large-7
                 %span.question_answer_links

--- a/app/views/searches/_answer.html.haml
+++ b/app/views/searches/_answer.html.haml
@@ -12,7 +12,7 @@
         - if content=result.excerpts.text.presence
           = raw content
         - else
-          = raw HTML_Truncator.truncate(render_md(result.text), 100)
+          = raw HTML_Truncator.truncate(render_md(result.text), 120, {:length_in_chars => true})
 
   .columns.large-3
     .row


### PR DESCRIPTION
Fix HTML truncation.  Without setting the truncation to be done by the length in characters it really doesn't seem to do anything.

Should look at setting this through default options in HTML Truncater.