### PR TITLE
Add API

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,16 @@
+class Api::BaseController < ApplicationController
+  include ApiHelper
+
+  skip_before_action :authenticate_user!
+  before_action :authenticate_api
+
+  protected
+
+    def authenticate_api
+      if AppConfig[:api_key] != params[:api_key]
+        render :text => "Sorry, you don't have access.", :status => 403
+        return
+      end
+    end
+
+end

--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -1,0 +1,19 @@
+class Api::QuestionsController < Api::BaseController
+
+  def show
+    question = Question.friendly.find(params[:id])
+
+    respond_to do |format|
+      format.json do
+        render :json => {
+          title: question.title,
+          text: question.text,
+          creator: question.creator.try(:name),
+          resource_url: resource_url(question),
+          answers: question.answers.map{|answer| {answer_text: answer.text, creator: answer.creator.try(:name)} }
+        }
+      end
+    end
+  end
+
+end

--- a/app/controllers/api/search_controller.rb
+++ b/app/controllers/api/search_controller.rb
@@ -1,0 +1,25 @@
+class Api::SearchController < Api::BaseController
+
+  def index
+    results = get_sphinx_search_results params[:q], params[:filter]
+    results.map! do |result|
+      label = if result.try(:name) && result.try(:description)
+        "#{result.name}: #{result.description}"
+      else
+        result.title
+      end
+      {
+        label: label,
+        category: result.class.model_name.human,
+        url: api_resource_url(result)
+      }
+    end
+
+    respond_to do |format|
+      format.json do
+        render :json => results.to_a
+      end
+    end
+  end
+
+end

--- a/app/controllers/api/topics_controller.rb
+++ b/app/controllers/api/topics_controller.rb
@@ -1,0 +1,19 @@
+class Api::TopicsController < Api::BaseController
+
+  def show
+    topic = Topic.friendly.find(params[:id])
+
+    respond_to do |format|
+      format.json do
+        render :json => {
+          title: topic.name,
+          description: topic.description,
+          text: topic.content,
+          creator: topic.creator.try(:name),
+          resource_url: resource_url(topic)
+        }
+      end
+    end
+  end
+
+end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,5 +1,5 @@
 class SearchesController < ApplicationController
-
+  include SearchHelper
   skip_after_action :track_action
 
   def index
@@ -26,13 +26,13 @@ class SearchesController < ApplicationController
   end
 
   private
+
   def get_sphinx_search_results(term)
     ThinkingSphinx.search Riddle::Query.escape(term),
-                          :excerpts => { :limit=>255, :around=>50 },
-                          :classes => [Question, Answer, Topic, Note],
-                          :with=>{ :tenant_id => Tenant.current_id },
-                          :per_page => per_page, :page=>params[:page]
-
+                        :excerpts => { :limit=>255, :around=>50 },
+                        :classes => [Question, Answer, Topic, Note],
+                        :with=>{ :tenant_id => Tenant.current_id },
+                        :per_page => per_page, :page=>params[:page]
   end
 
   def per_page

--- a/app/helpers/api_helper.rb
+++ b/app/helpers/api_helper.rb
@@ -1,0 +1,29 @@
+module ApiHelper
+
+  def get_sphinx_search_results(term, filter='question,answer,topic')
+    filter_by = filter.split(',').map{ |f| f.capitalize.constantize }
+    ThinkingSphinx.search Riddle::Query.escape(term),
+                        :excerpts => { :limit=>255, :around=>50 },
+                        :classes => filter_by,
+                        :with=>{ :tenant_id => Tenant.current_id },
+                        :per_page => per_page, :page=>params[:page]
+  end
+
+  def api_resource_url(resource)
+    res = resource.instance_of?(Answer) ? resource.question : resource
+    return "" if res.nil?
+    url_for controller: "api/#{res.class.name.tableize}",
+            action: :show,
+            format: :json,
+            id: res.try(:slug)
+  end
+
+  def resource_url(resource)
+    resource.instance_of?(Answer) ? url_for(resource.question) : url_for(resource)
+  end
+
+  def per_page
+    40
+  end
+
+end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,6 +1,5 @@
 module SearchHelper
 
-
   def render_search_results search
     results = ""
     debugger

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,15 @@ Tribalknow::Application.routes.draw do
       end
     end
   end
-  
+
+  # API
+  namespace :api do
+    resources :search, only: [:index]
+    resources :questions, only: [:show]
+    resources :answers, only: [:show]
+    resources :topics, only: [:show]
+  end
+
   post '/votes' => 'votes#create'
 
   get '/todo' => 'homes#todo'


### PR DESCRIPTION
adding API for integration with other services

@edk some time ago I asked for the API here https://github.com/edk/tribalknow/issues/24 where you wanted to add API key to the user..

instead I added `api_key` to the config. so one API key for all.

<img width="866" alt="screenshot 2017-01-11 19 48 02" src="https://cloud.githubusercontent.com/assets/194539/21861971/8d2be726-d837-11e6-8cf8-35523d327a9a.png">

then you can use:
  - http://localhost:3000/api/search.json?api_key=123123&q= for a search
  - http://localhost:3000/api/questions/silencing-rails-schema-load.json?api_key=123123 for getting content of question/answer/topic/etc

I want to integrate my `CCC: Coupa CLI` project with q.coupadev.com by adding `q` script. 

see how it works:

![hvbsej8xxz](https://cloud.githubusercontent.com/assets/194539/21862260/bb8b042a-d838-11e6-8deb-a65a5b09ffa9.gif)

this way simplify integration with other services. so i don't need to ask coupa's users go register then grab api key, add it to the config to make it work. instead it's just integrated and works from the box.

from the security standpoint i think it should be fine because this `CCC: Coupa CLI` is available only for coupa's employers (github auth + check coupa's member). so the APi will be stored inside the command. we are able to change API key whatever we want to, it'll be supported by `ccc` installer. we can also be specific and in q's configuration call the API key as `ccc_api_key` to be used only by ccc