### PR TITLE
allow textarea resizing for question, answer, and topic editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ log/*.pid
 #config/database.yml
 config/*-prod
 
+/*.dump
+
 postgres
 mysql
 redis

--- a/app/javascript/stylesheets/site_styles.scss
+++ b/app/javascript/stylesheets/site_styles.scss
@@ -73,3 +73,7 @@ ul.panel_list.toc_tree {
     margin-left: 1em;
   }
 }
+
+.resizeable-textarea{
+  resize: both;
+}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,7 +12,6 @@
 
     = javascript_pack_tag "application"
     = stylesheet_pack_tag "#{user_theme}"
-    =# stylesheet_pack_tag "darkly" # "#{some_theme_name}"
 
     = yield(:head_stylesheet)
     = csrf_meta_tags

--- a/app/views/questions/_add_answer.html.haml
+++ b/app/views/questions/_add_answer.html.haml
@@ -1,14 +1,13 @@
-- if question.answers.empty?
-  %h5= "No answers yet, be the first to add yours!"
-- else
-  %h5= "Add your answer..."
+%h5.card-title
+  = question.answers.empty? ? "No answers yet, be the first to add yours!" : "Add your answer..."
 
 .row
-  .col-lg-10
+  .col-lg-12
     = simple_form_for [question, Answer.new], :url=>question_answers_path(question) do |f|
       #in.row
-        = f.text_area :text, class: ''
+        .col-lg-12
+          = f.text_area :text, class: "form-control resizeable-textarea", rows: "4"
       #out
       .row
-        .col-lg-2
+        .col-lg-12.mt-2
           = f.submit 'Submit answer', :class => 'btn btn-primary'

--- a/app/views/questions/_form.html.haml
+++ b/app/views/questions/_form.html.haml
@@ -21,15 +21,14 @@
 
   - if @question.new_record?
     .row
-      .small-8
+      .col-lg-8
         %h3= "Add an answer to this question (if ya gots one)..."
     %br/
     .row
       .col-lg-10
-        = text_area_tag :answer_text, '', style:'height:8em'
+        = text_area_tag :answer_text, '', rows: "8", class: "form-control resizeable-textarea"
 
   .actions
     .row
-      .col-lg-4
-        = f.submit 'Submit Question', :class => 'button expand'
-      .col-lg-4
+      .col-lg-4.mt-2
+        = f.submit 'Submit Question', :class => 'button expand btn btn-primary'

--- a/app/views/questions/show.html.haml
+++ b/app/views/questions/show.html.haml
@@ -28,4 +28,6 @@
 
 .row
   .col-lg-12
-    .card= render :partial=>'add_answer', :locals=>{:question=>@question} unless @static_render
+    .card
+      .card-body
+        = render :partial=>'add_answer', :locals=>{:question=>@question} unless @static_render

--- a/app/views/topics/_form.html.haml
+++ b/app/views/topics/_form.html.haml
@@ -1,7 +1,7 @@
 
 = simple_form_for(@topic) do |f|
   = f.error_notification
-  .row
+  .row.mt-4
     .col-lg-7
       .row
         .col-lg-6
@@ -23,14 +23,14 @@
     .col-lg-4.markdown_tip.right
       = link_to "We use Github flavored markdown.", "https://guides.github.com/features/mastering-markdown/", target: "_blank"
       = link_to "Use native apps", "http://macdown.uranusjr.com/", target: "_blank"
-    .col-lg-12
-      #in{style: "height: 25em; min-height:25em;"}
-        = f.text_area :content
-      #out{style: "min-height: 20em;"}
+    .col-lg-10
+      #in
+        = f.text_area :content, class: "form-control resizeable-textarea", rows: "10"
+      #out
   .actions
     .row
-      .col-lg-4
-        = f.submit "Save", :class => 'btn btn-primary has-tip', :style=>"color: #EEE", :title=>'Tip: CMD-s saves when in the editor!', :data=>{:tooltip=>""}
-      .col-lg-4
-      .col-lg-4
+      .col-lg-4.mt-2
+        = f.submit "Save", class: 'btn btn-primary'
+        .form-text
+          Tip: CMD-s saves when in the editor!
 


### PR DESCRIPTION
## Summary of issue

Without the JS markdown editor, several textareas seem to be set to a small default size, and the bootstrap styles set textarea to only be resizeable vertically.

## Summary of change

- Set full-width default size for several text areas with bootstrap
- Added a class to allow resizeability in both directions
- tweaked alignment of forms with bootstrap 

![Screen Shot 2020-11-02 at 18 29 25-fullpage](https://user-images.githubusercontent.com/1171115/97944544-d3e0d280-1d39-11eb-879a-76d06406deb7.png)
![Screen Shot 2020-11-02 at 18 29 00-fullpage](https://user-images.githubusercontent.com/1171115/97944548-d511ff80-1d39-11eb-8a03-8d7a1b8f7e90.png)
![Screen Shot 2020-11-02 at 18 28 44-fullpage](https://user-images.githubusercontent.com/1171115/97944552-d6432c80-1d39-11eb-9ee9-ad045012f6fe.png)
