### PR TITLE
Add an optional middleware to redirect non-tenant domains to default domain before other processing, to support moved TribalKnow instances.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
-
   include Pundit
   protect_from_forgery with: :exception
 
@@ -15,6 +14,7 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   private
+
   def current_tenant
     if Tenant.multi_tenant?
       current_tenant ||= Tenant.find_by subdomain: request.subdomain
@@ -40,9 +40,13 @@ class ApplicationController < ActionController::Base
     Tenant.current_id = nil
   end
 
+  def default_fqdn
+    @default_fqdn ||= ENV['DEFAULT_FQDN'].presence || Tenant.default_tenant&.fqdn
+  end
+
   def canonical_landing
-    if ENV['DEFAULT_FQDN'].presence
-      ENV['DEFAULT_FQDN']
+    if default_fqdn.presence
+      default_fqdn
     else
       "#{request.protocol}#{request.host.split('.')[-2..-1].join('.')}"
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,8 @@ module Tribalknow
     config.eager_load_paths << Rails.root.join("lib")
     config.eager_load_paths << Rails.root.join("app/channels")
     config.cache_store = :redis_store, ENV['REDIS_STORE_URL'] || "redis://localhost:6379/0/cache" #, { expires_in: 90.minutes }
+
+    require Rails.root.join("lib/domain_redirector_middleware")
+    config.middleware.use ::DomainRedirectorMiddleware
   end
 end

--- a/lib/domain_redirector_middleware.rb
+++ b/lib/domain_redirector_middleware.rb
@@ -1,0 +1,26 @@
+class DomainRedirectorMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    begin
+      return @app.call(env) unless ENV["USE_DOMAIN_MIDDLEWARE"] == "true" && env["REQUEST_METHOD"] == "GET"
+
+      request = Rack::Request.new(env)
+
+      default_fqdn = ENV['DEFAULT_FQDN'].presence || Tenant.default_tenant&.fqdn
+      request_hostname = request.hostname
+
+      if default_fqdn.present? && request_hostname.present? && request_hostname != default_fqdn && !Tenant.exists?(fqdn: request_hostname) && request_hostname != "localhost"
+        redirect_url = ActionDispatch::Http::URL.full_url_for({host: default_fqdn, protocol: request.scheme, port: request.port, path: request.fullpath})
+        return [301, {'Location' => redirect_url, 'Content-Type' => request.content_type}, ['Moved Permanently']]
+      else
+        @app.call(env)
+      end
+
+    rescue
+      @app.call(env)
+    end
+  end
+end


### PR DESCRIPTION
Written as a middleware instead of controller before_action calls because I wasn't having much luck extending Devise to cover logged-out requests.